### PR TITLE
maintenance: change += to = for append and remove commands

### DIFF
--- a/recipes-ostree/initramfs-framework-ostree/initramfs-framework_%.bbappend
+++ b/recipes-ostree/initramfs-framework-ostree/initramfs-framework_%.bbappend
@@ -4,7 +4,7 @@ SRC_URI += " \
     file://initramfs-framework.patch \
 "
 
-RDEPENDS:initramfs-module-rootfs:append += " \
+RDEPENDS:initramfs-module-rootfs:append = " \
     util-linux-fsck \
     e2fsprogs-e2fsck \
 "


### PR DESCRIPTION
This change was necessary to stop the following warning messages appear during a build: 

> WARNING: RRECOMMENDS:${PN}:append += is not a recommended operator combination, please replace it. 
> WARNING: RDEPENDS:${PN}:remove += is not a recommended operator combination, please replace it.
